### PR TITLE
Add completedAt field for tasks

### DIFF
--- a/src/main/src/modules/queryInit.module.ts
+++ b/src/main/src/modules/queryInit.module.ts
@@ -16,13 +16,14 @@ CREATE TABLE IF NOT EXISTS task (
     title TEXT NOT NULL,  
     description TEXT,  
     kanbanColumnId INTEGER NOT NULL,  
-    folderId INTEGER,  
-    createdAt TEXT DEFAULT CURRENT_TIMESTAMP,  
-    updatedAt TEXT DEFAULT CURRENT_TIMESTAMP,  
-    deletedAt TEXT,  
-    FOREIGN KEY (kanbanColumnId) REFERENCES kanbanColumn(id),  
-    FOREIGN KEY (folderId) REFERENCES folder(id)  
-);  
+    folderId INTEGER,
+    createdAt TEXT DEFAULT CURRENT_TIMESTAMP,
+    updatedAt TEXT DEFAULT CURRENT_TIMESTAMP,
+    completedAt TEXT,
+    deletedAt TEXT,
+    FOREIGN KEY (kanbanColumnId) REFERENCES kanbanColumn(id),
+    FOREIGN KEY (folderId) REFERENCES folder(id)
+);
 
 CREATE TABLE IF NOT EXISTS kanbanColumn (  
     id INTEGER PRIMARY KEY AUTOINCREMENT,  
@@ -63,7 +64,9 @@ CREATE TABLE IF NOT EXISTS password (
     createdAt TEXT DEFAULT CURRENT_TIMESTAMP,  
     updatedAt TEXT DEFAULT CURRENT_TIMESTAMP,  
     deletedAt TEXT,  
-    FOREIGN KEY (folderId) REFERENCES folder(id)  
-);  
+    FOREIGN KEY (folderId) REFERENCES folder(id)
+);
+
+ALTER TABLE IF NOT EXISTS task ADD COLUMN completedAt TEXT;
 `  
 }

--- a/src/main/src/types/global.d.ts
+++ b/src/main/src/types/global.d.ts
@@ -19,6 +19,7 @@ interface Task {
     folderId?: number;
     createdAt: string;
     updatedAt: string;
+    completedAt?: string;
     deletedAt?: string;
 }
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -69,6 +69,7 @@ declare global {
     folderId?: number
     createdAt: string
     updatedAt: string
+    completedAt?: string
     deletedAt?: string
   }
 


### PR DESCRIPTION
## Summary
- extend SQL schema for tasks with `completedAt`
- update `Task` interface definitions
- handle existing databases by altering the table on startup

## Testing
- `npm run lint` *(fails: Cannot find package '@electron-toolkit/eslint-config-ts')*
- `npm run typecheck` *(fails: Cannot find type definition file for 'electron-vite/node')*

------
https://chatgpt.com/codex/tasks/task_e_684592347cfc832d955f7a44fa4625fd