### PR TITLE
Fix SQLite initialization timing

### DIFF
--- a/src/main/src/modules/crud.module.ts
+++ b/src/main/src/modules/crud.module.ts
@@ -1,7 +1,8 @@
-import dbInstance from "./sqllite.module";
+import { getDB } from './sqllite.module';
 
 // 🔥 CRUD generici
 function create<T>(table: string, data: Partial<T>): number {
+  const dbInstance = getDB();
   const keys = Object.keys(data).join(', ');
   const placeholders = Object.keys(data).map(() => '?').join(', ');
   const values = Object.values(data);
@@ -12,17 +13,20 @@ function create<T>(table: string, data: Partial<T>): number {
 }
 
 function readAll<T>(table: string): T[] {
+  const dbInstance = getDB();
   const sql = `SELECT * FROM ${table} WHERE deletedAt IS NULL`;
   return dbInstance.runQuery<T>(sql);
 }
 
 function readById<T>(table: string, id: number): T | undefined {
+  const dbInstance = getDB();
   const sql = `SELECT * FROM ${table} WHERE id = ? AND deletedAt IS NULL`;
   const result = dbInstance.runQuery<T>(sql, [id]);
   return result[0];
 }
 
 function update<T>(table: string, id: number, data: Partial<T>): void {
+  const dbInstance = getDB();
   const setClause = Object.keys(data).map(key => `${key} = ?`).join(', ');
   const values = [...Object.values(data), id];
 
@@ -31,6 +35,7 @@ function update<T>(table: string, id: number, data: Partial<T>): void {
 }
 
 function softDelete(table: string, id: number): void {
+  const dbInstance = getDB();
   const sql = `UPDATE ${table} SET deletedAt = CURRENT_TIMESTAMP WHERE id = ?`;
   dbInstance.runQuery(sql, [id]);
 }

--- a/src/main/src/modules/initialize.module.ts
+++ b/src/main/src/modules/initialize.module.ts
@@ -1,7 +1,7 @@
-import dbInstance from './sqllite.module'
+import { getDB } from './sqllite.module'
 import { mainsql } from './queryInit.module'
 
 export function initialize() {
   console.log('init check')
-  dbInstance.runSQLScript(mainsql())
+  getDB().runSQLScript(mainsql())
 }

--- a/src/main/src/modules/sqllite.module.ts
+++ b/src/main/src/modules/sqllite.module.ts
@@ -50,5 +50,16 @@ runSQLScript(sqlScript: string) {
   }
 }
 
-const dbInstance = new SQLiteDB();
-export default dbInstance;
+let dbInstance: SQLiteDB | null = null;
+
+export function getDB(): SQLiteDB {
+  if (!dbInstance) {
+    if (!app.isReady()) {
+      throw new Error('Database accessed before Electron app is ready');
+    }
+    dbInstance = new SQLiteDB();
+  }
+  return dbInstance;
+}
+
+export default getDB;


### PR DESCRIPTION
## Summary
- ensure the SQLite DB is created only after Electron app is ready
- update CRUD functions and initialization logic accordingly

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'electron-vite/node')*
- `npm run lint` *(fails: Cannot find package '@electron-toolkit/eslint-config-ts')*

------
https://chatgpt.com/codex/tasks/task_e_684591403f28832da07c9a46b3c8f23a